### PR TITLE
Shorten pyparsing tracebacks, to clear out internal pyparsing calls; …

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -95,6 +95,11 @@ Version 3.0.0a1
                  or
         fwd << (expr_a | expr_b)
 
+- Cleaned up default tracebacks when getting a ParseException when calling
+  parseString. Exception traces should now stop at the call in parseString,
+  and not include the internal traceback frames. (If the full traceback
+  is desired, then set ParserElement.verbose_traceback to True.)
+
 - Fixed FutureWarnings that sometimes are raised when '[' passed as a
   character to Word.
 

--- a/pyparsing/core.py
+++ b/pyparsing/core.py
@@ -249,6 +249,12 @@ class ParserElement(object):
     DEFAULT_WHITE_CHARS = " \n\t\r"
     verbose_stacktrace = False
 
+    @classmethod
+    def _trim_traceback(cls, tb):
+        while tb.tb_next:
+            tb = tb.tb_next
+        return tb
+
     @staticmethod
     def setDefaultWhitespaceChars(chars):
         r"""
@@ -801,7 +807,8 @@ class ParserElement(object):
             if ParserElement.verbose_stacktrace:
                 raise
             else:
-                # catch and re-raise exception from here, clears out pyparsing internal stack trace
+                # catch and re-raise exception from here, clearing out pyparsing internal stack trace
+                exc.__traceback__ = self._trim_traceback(exc.__traceback__)
                 raise exc
         else:
             return tokens
@@ -876,6 +883,7 @@ class ParserElement(object):
                 raise
             else:
                 # catch and re-raise exception from here, clears out pyparsing internal stack trace
+                exc.__traceback__ = self._trim_traceback(exc.__traceback__)
                 raise exc
 
     def transformString(self, instring):
@@ -922,6 +930,7 @@ class ParserElement(object):
                 raise
             else:
                 # catch and re-raise exception from here, clears out pyparsing internal stack trace
+                exc.__traceback__ = self._trim_traceback(exc.__traceback__)
                 raise exc
 
     def searchString(self, instring, maxMatches=_MAX_INT):
@@ -954,6 +963,7 @@ class ParserElement(object):
                 raise
             else:
                 # catch and re-raise exception from here, clears out pyparsing internal stack trace
+                exc.__traceback__ = self._trim_traceback(exc.__traceback__)
                 raise exc
 
     def split(self, instring, maxsplit=_MAX_INT, includeSeparators=False):
@@ -1476,6 +1486,7 @@ class ParserElement(object):
                 raise
             else:
                 # catch and re-raise exception from here, clears out pyparsing internal stack trace
+                exc.__traceback__ = self._trim_traceback(exc.__traceback__)
                 raise exc
 
     def __eq__(self, other):

--- a/pyparsing/results.py
+++ b/pyparsing/results.py
@@ -455,7 +455,7 @@ class ParseResults(object):
         Returns a new copy of a :class:`ParseResults` object.
         """
         ret = ParseResults(self.__toklist)
-        ret.__tokdict = dict(self.__tokdict.items())
+        ret.__tokdict.update(self.__tokdict)
         ret.__parent = self.__parent
         ret.__accumNames.update(self.__accumNames)
         ret.__name = self.__name

--- a/pyparsing/util.py
+++ b/pyparsing/util.py
@@ -75,10 +75,11 @@ def line(loc, strg):
 class _UnboundedCache:
     def __init__(self):
         cache = {}
+        cache_get = cache.get
         self.not_in_cache = not_in_cache = object()
 
         def get(self, key):
-            return cache.get(key, not_in_cache)
+            return cache_get(key, not_in_cache)
 
         def set(self, key, value):
             cache[key] = value
@@ -99,15 +100,16 @@ class _FifoCache:
     def __init__(self, size):
         self.not_in_cache = not_in_cache = object()
         cache = collections.OrderedDict()
+        cache_get = cache.get
 
         def get(self, key):
-            return cache.get(key, not_in_cache)
+            return cache_get(key, not_in_cache)
 
         def set(self, key, value):
             cache[key] = value
             try:
                 while len(cache) > size:
-                    cache.popitem(False)
+                    cache.popitem(last=False)
             except KeyError:
                 pass
 


### PR DESCRIPTION
…plus some micro-optimizations when using packrat parsing